### PR TITLE
Add OAuthTokenResponse

### DIFF
--- a/src/interfaces/miscellaneous/OAuthTokenResponse.ts
+++ b/src/interfaces/miscellaneous/OAuthTokenResponse.ts
@@ -1,0 +1,5 @@
+export default interface OAuthTokenResponse {
+  access_token: string,
+  token_type: "Bearer",
+  expires_in: number,
+}

--- a/src/interfaces/miscellaneous/index.ts
+++ b/src/interfaces/miscellaneous/index.ts
@@ -1,5 +1,7 @@
 import ModrinthStatistics from "./ModrinthStatistics";
-
+import OAuthTokenResponse from "./OAuthTokenResponse;
+    
 export {
-    ModrinthStatistics
+    ModrinthStatistics,
+    OAuthTokenResponse
 }


### PR DESCRIPTION
Response type received when calling `https://api.modrinth.com/_internal/oauth/token` after receiving an OAuth2 code.